### PR TITLE
Retry handler design spec. update

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Microsoft Graph
+Copyright (c) 2019 Microsoft Graph
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/middleware/RetryHandler.md
+++ b/middleware/RetryHandler.md
@@ -10,10 +10,11 @@ Provide a reusuable component that provides application developers with effectiv
 - A `retry-attempt` header SHOULD be added which contains a numeric value representing the retry number.  This value will be used for diagnostics and determining the effectiveness of the retry handler.
 - Retries MUST respect the `retry-after` response header if provided.
 - Where no `retry-after` header is provided by the server, an exponential backoff with random offset hueristic should be used to determine the retry delay.
-- Retries should be limited to a maximum value.
-- This value MUST be specified by the client code.
-- Retries will be based on the cumulative retry delay against the maximum retry time specified by the client code.
-- Upon expiry of the maximum retry time, the Task should be cancelled and an exception thrown.
+- Retries should be limited to a maximum delay value. The default value for this is set at 180 seconds.
+- The client code can specify a custom value for the maximum delay.
+- Retries will be based on the cumulative retry delay compared against the maximum delay specified by the client code.
+- Upon expiry of the maximum delay, when the cumulative retry delay is greater than the specified maximum delay, the `Task` should be cancelled and an `exception` thrown with a relevant message.
+- In the case whereby the client code specifies a maximum delay that is less than the received `retry-after` header value from the server, the cumulative retry delay will run for the duration of the `retry-after` value.
 - Only requests with payloads that are buffered/rewindable are supported.  Payloads with forward only streams will be have the responses returned without any retry attempt.
 
 ### Supported Status Codes

--- a/middleware/RetryHandler.md
+++ b/middleware/RetryHandler.md
@@ -11,6 +11,9 @@ Provide a reusuable component that provides application developers with effectiv
 - Retries MUST respect the `retry-after` response header if provided.
 - Where no `retry-after` header is provided by the server, an exponential backoff with random offset hueristic should be used to determine the retry delay.
 - Retries should be limited to a maximum value.
+- This value MUST be specified by the client code.
+- Retries will be based on the cumulative retry delay against the maximum retry time specified by the client code.
+- Upon expiry of the maximum retry time, the Task should be cancelled and an exception thrown.
 - Only requests with payloads that are buffered/rewindable are supported.  Payloads with forward only streams will be have the responses returned without any retry attempt.
 
 ### Supported Status Codes

--- a/middleware/RetryHandler.md
+++ b/middleware/RetryHandler.md
@@ -11,7 +11,7 @@ Provide a reusuable component that provides application developers with effectiv
 - Retries MUST respect the `retry-after` response header if provided.
 - Where no `retry-after` header is provided by the server, an exponential backoff with random offset hueristic should be used to determine the retry delay.
 - Customers can specify a custom value for the `RetriesTimeLimit` greater than 0 to introduce time-based evaluated request retries alongside the default count-based request retry. The default is set at 0 second.
-- If the `RetriesTimeLimit` value has been specified, the cumulative retry time and `retry-after` value for each request retry will be evaluated against this value; if either the cumulative retry time or `retry-after` value is greater than the `RetriesTimeLimit`, the failed response will be immediately returned, else the request retry continues. This is applicable to both 429 and 503/504.
+- If the `RetriesTimeLimit` value has been specified, the cumulative retry time and `retry-after` value for each request retry will be evaluated against this value; if the cumulative retry time plus the `retry-after` value is greater than the `RetriesTimeLimit`, the failed response will be immediately returned, else the request retry continues. This is applicable to both 429 and 503/504.
 - Only requests with payloads that are buffered/rewindable are supported. Payloads with forward only streams will be have the responses returned without any retry attempt.
 
 ### Supported Status Codes

--- a/middleware/RetryHandler.md
+++ b/middleware/RetryHandler.md
@@ -10,7 +10,7 @@ Provide a reusuable component that provides application developers with effectiv
 - A `retry-attempt` header SHOULD be added which contains a numeric value representing the retry number.  This value will be used for diagnostics and determining the effectiveness of the retry handler.
 - Retries MUST respect the `retry-after` response header if provided.
 - Where no `retry-after` header is provided by the server, an exponential backoff with random offset hueristic should be used to determine the retry delay.
-- Customers can specify a custom value for the `RetriesTimeLimit` greater than 0 to introduce time-based evaluated request retries alongside the default count-based request retry. The default is set at 0 second.
+- Customers can specify a custom value for the `RetriesTimeLimit` greater than 0 to introduce time-based evaluated request retries alongside the default count-based request retry.
 - If the `RetriesTimeLimit` value has been specified, the cumulative retry time and `retry-after` value for each request retry will be evaluated against this value; if the cumulative retry time plus the `retry-after` value is greater than the `RetriesTimeLimit`, the failed response will be immediately returned, else the request retry continues. This is applicable to both 429 and 503/504.
 - Only requests with payloads that are buffered/rewindable are supported. Payloads with forward only streams will be have the responses returned without any retry attempt.
 

--- a/middleware/RetryHandler.md
+++ b/middleware/RetryHandler.md
@@ -12,7 +12,7 @@ Provide a reusuable component that provides application developers with effectiv
 - Where no `retry-after` header is provided by the server, an exponential backoff with random offset hueristic should be used to determine the retry delay.
 - Retries should be limited to a maximum delay value. The default value for this is set at 180 seconds.
 - The client code can specify a custom value for the maximum delay.
-- Retries will be based on the cumulative retry delays compared against the maximum delay specified by the client code, cumulatively added across all retries within the context of a single call. This is applicable to both 429 and 503/504.
+- Multiple retry attempts will be limited to not exceed the `RetriesTimeLimit`. This is applicable to both 429 and 503/504.
 - Upon expiry of the maximum delay, when the cumulative retry delay is greater than the specified maximum delay, the `Task` should be cancelled and an `exception` thrown with a relevant message.
 - In the case where the client receives a `retry-after` value that is greater than the remaining `RetriesTimeLimit` the client should return the failed response immediately.
 - Only requests with payloads that are buffered/rewindable are supported.  Payloads with forward only streams will be have the responses returned without any retry attempt.

--- a/middleware/RetryHandler.md
+++ b/middleware/RetryHandler.md
@@ -12,7 +12,7 @@ Provide a reusuable component that provides application developers with effectiv
 - Where no `retry-after` header is provided by the server, an exponential backoff with random offset hueristic should be used to determine the retry delay.
 - Retries should be limited to a maximum delay value. The default value for this is set at 180 seconds.
 - The client code can specify a custom value for the maximum delay.
-- Retries will be based on the cumulative retry delay compared against the maximum delay specified by the client code.
+- Retries will be based on the cumulative retry delays compared against the maximum delay specified by the client code, cumulatively added across all retries within the context of a single call. This is applicable to both 429 and 503/504.
 - Upon expiry of the maximum delay, when the cumulative retry delay is greater than the specified maximum delay, the `Task` should be cancelled and an `exception` thrown with a relevant message.
 - In the case whereby the client code specifies a maximum delay that is less than the received `retry-after` header value from the server, the cumulative retry delay will run for the duration of the `retry-after` value.
 - Only requests with payloads that are buffered/rewindable are supported.  Payloads with forward only streams will be have the responses returned without any retry attempt.

--- a/middleware/RetryHandler.md
+++ b/middleware/RetryHandler.md
@@ -14,7 +14,7 @@ Provide a reusuable component that provides application developers with effectiv
 - The client code can specify a custom value for the maximum delay.
 - Retries will be based on the cumulative retry delays compared against the maximum delay specified by the client code, cumulatively added across all retries within the context of a single call. This is applicable to both 429 and 503/504.
 - Upon expiry of the maximum delay, when the cumulative retry delay is greater than the specified maximum delay, the `Task` should be cancelled and an `exception` thrown with a relevant message.
-- In the case whereby the client code specifies a maximum delay that is less than the received `retry-after` header value from the server, the cumulative retry delay will run for the duration of the `retry-after` value.
+- In the case where the client receives a `retry-after` value that is greater than the remaining `RetriesTimeLimit` the client should return the failed response immediately.
 - Only requests with payloads that are buffered/rewindable are supported.  Payloads with forward only streams will be have the responses returned without any retry attempt.
 
 ### Supported Status Codes

--- a/middleware/RetryHandler.md
+++ b/middleware/RetryHandler.md
@@ -10,10 +10,8 @@ Provide a reusuable component that provides application developers with effectiv
 - A `retry-attempt` header SHOULD be added which contains a numeric value representing the retry number.  This value will be used for diagnostics and determining the effectiveness of the retry handler.
 - Retries MUST respect the `retry-after` response header if provided.
 - Where no `retry-after` header is provided by the server, an exponential backoff with random offset hueristic should be used to determine the retry delay.
-- The client code can specify a custom value for the maximum delay value for time-based retries. The default is set at 0 second.
-- Multiple retry attempts will be limited to not exceed the `RetriesTimeLimit` in the case of time-based retries and `RetryCounts` in count-based retries. This is applicable to both 429 and 503/504.
-- In the case where the client receives a `retry-after` value that is greater than the remaining `RetriesTimeLimit` the client should return the failed response immediately.
-- Customers who intend to use the time-based retry will need to provide a maximum delay value in seconds greater than 0 for `RetriesTimeLimit`, otherwise the count-based retry will be used by default.
+- Customers can specify a custom value for the `RetriesTimeLimit` greater than 0 to introduce time-based evaluated request retries alongside the default count-based request retry. The default is set at 0 second.
+- If the `RetriesTimeLimit` value has been specified, the cumulative retry time and `retry-after` value for each request will be evaluated against this value; if either the cumulative retry time or `retry-after` value is greater than the `RetriesTimeLimit`, the failed response will be immediately returned, else the retry request continues. This is applicable to both 429 and 503/504.
 - Only requests with payloads that are buffered/rewindable are supported. Payloads with forward only streams will be have the responses returned without any retry attempt.
 
 ### Supported Status Codes

--- a/middleware/RetryHandler.md
+++ b/middleware/RetryHandler.md
@@ -11,7 +11,7 @@ Provide a reusuable component that provides application developers with effectiv
 - Retries MUST respect the `retry-after` response header if provided.
 - Where no `retry-after` header is provided by the server, an exponential backoff with random offset hueristic should be used to determine the retry delay.
 - Customers can specify a custom value for the `RetriesTimeLimit` greater than 0 to introduce time-based evaluated request retries alongside the default count-based request retry. The default is set at 0 second.
-- If the `RetriesTimeLimit` value has been specified, the cumulative retry time and `retry-after` value for each request will be evaluated against this value; if either the cumulative retry time or `retry-after` value is greater than the `RetriesTimeLimit`, the failed response will be immediately returned, else the retry request continues. This is applicable to both 429 and 503/504.
+- If the `RetriesTimeLimit` value has been specified, the cumulative retry time and `retry-after` value for each request retry will be evaluated against this value; if either the cumulative retry time or `retry-after` value is greater than the `RetriesTimeLimit`, the failed response will be immediately returned, else the request retry continues. This is applicable to both 429 and 503/504.
 - Only requests with payloads that are buffered/rewindable are supported. Payloads with forward only streams will be have the responses returned without any retry attempt.
 
 ### Supported Status Codes

--- a/middleware/RetryHandler.md
+++ b/middleware/RetryHandler.md
@@ -10,12 +10,11 @@ Provide a reusuable component that provides application developers with effectiv
 - A `retry-attempt` header SHOULD be added which contains a numeric value representing the retry number.  This value will be used for diagnostics and determining the effectiveness of the retry handler.
 - Retries MUST respect the `retry-after` response header if provided.
 - Where no `retry-after` header is provided by the server, an exponential backoff with random offset hueristic should be used to determine the retry delay.
-- Retries should be limited to a maximum delay value. The default value for this is set at 180 seconds.
-- The client code can specify a custom value for the maximum delay.
-- Multiple retry attempts will be limited to not exceed the `RetriesTimeLimit`. This is applicable to both 429 and 503/504.
-- Upon expiry of the maximum delay, when the cumulative retry delay is greater than the specified maximum delay, the `Task` should be cancelled and an `exception` thrown with a relevant message.
+- The client code can specify a custom value for the maximum delay value for time-based retries. The default is set at 0 second.
+- Multiple retry attempts will be limited to not exceed the `RetriesTimeLimit` in the case of time-based retries and `RetryCounts` in count-based retries. This is applicable to both 429 and 503/504.
 - In the case where the client receives a `retry-after` value that is greater than the remaining `RetriesTimeLimit` the client should return the failed response immediately.
-- Only requests with payloads that are buffered/rewindable are supported.  Payloads with forward only streams will be have the responses returned without any retry attempt.
+- Customers who intend to use the time-based retry will need to provide a maximum delay value in seconds greater than 0 for `RetriesTimeLimit`, otherwise the count-based retry will be used by default.
+- Only requests with payloads that are buffered/rewindable are supported. Payloads with forward only streams will be have the responses returned without any retry attempt.
 
 ### Supported Status Codes
 


### PR DESCRIPTION
This PR updates the design spec. for the retry handler middleware proposing to change the count-based request retries to time-based request retries. 

From task: microsoftgraph/msgraph-sdk-dotnet/issues/441