### PR TITLE
- updates large file upload task spec java examples

### DIFF
--- a/tasks/FileUploadTask.md
+++ b/tasks/FileUploadTask.md
@@ -20,7 +20,7 @@ This task aims to provide a fluent and easy to use mechanism for the consumer to
 - The task classes naming should match **LargeFileUploadXXX** (provider, result...) and all the classes should live in a **tasks** subnamespace, and be sharing the same  namespace as the **PageIterator** task.
 - The task should be agnostic to the kind of upload being performed so as to support for various fileUpload scenarios e.g. **DriveItem** and **FileAttachment**. An example of the agnostic nature of task is how the task is marked as completed considering different response formats from each API:
   - If the response status is a 201.
-  - For OneDrive if the response status is a 200 and the response contains an "id" then the task is complete.
+  - An additional case for OneDrive is, if the response status is a 200 and the response contains an "id" then the task is complete.
   
 > Note: Outlook and Print API does not allow to update an attachment after it has been uploaded.
 

--- a/tasks/FileUploadTask.md
+++ b/tasks/FileUploadTask.md
@@ -18,7 +18,7 @@ This task aims to provide a fluent and easy to use mechanism for the consumer to
 - The task should not retry to upload failed slices as any retry should already be done by the retry-handler which the task should be using.
 - The task should be agnostic to the kind of upload being performed so as to support for various fileUpload scenarios e.g. **DriveItem** and **FileAttachment**.
 - The task should provide cancellation capabilities through native task cancellation sources when using async APIs.
-- The task classes naming should match **LargeFileUploadXXX** (provider, result...) and all the classes should live in a **tasks** subnamespace, and be sharing the same  namespace at the **PageIterator** task.
+- The task classes naming should match **LargeFileUploadXXX** (provider, result...) and all the classes should live in a **tasks** subnamespace, and be sharing the same  namespace as the **PageIterator** task.
 - An upload task should be marked as completed if the response status is a 201. Another condition valid only for OneDrive is if the response status is a 200 and the response contains an "id" then the task is complete. Note - Outlook and Print API does not allow to update an attachment.
 - Refer to the following documentation for more information:
 
@@ -38,7 +38,7 @@ Json Schema with a generic type for the object:
   "type": "object",
   "properties": {
     "location": { "type": "string"},
-    "object": { "type":  "generic"},
+    "responseBody": { "type":  "generic"},
   }
 }
 ```

--- a/tasks/FileUploadTask.md
+++ b/tasks/FileUploadTask.md
@@ -34,8 +34,8 @@ Refer to the following documentation for more information:
 
 Json Schema with a generic type for the object:
 
-- In case only an id is provided by the response, it'll be set as the id of the object.
-- In case a location header is returned by the service, the property will be set and the object will be left null.
+- In case only an id is provided by the response, it'll be set as the id of the responseBody.
+- In case a location header is returned by the service, the property will be set and the responseBody will be left null.
 
 ```json
 {
@@ -46,6 +46,32 @@ Json Schema with a generic type for the object:
   }
 }
 ```
+
+> Warning: the location header casing can be different between HTTP/1.1 **Location** and HTTP/2. Implementation should account for this.
+
+## Large Upload Sequence
+
+1. The consumer creates a large upload session using the SDK.
+1. The consumer opens a stream to the file that needs to be uploaded (from storage, network, memory...).
+1. The consumer creates a large upload task (this object model) passing the upload session, upload parameters, and the stream.
+1. The consumer calls the **upload** method which:
+    1. Reads the next bytes according to parameters
+    1. Performs the upload request.
+    1. Reads the response to determine whether a next range of bytes is expected, or the upload is completed, or whether the upload has failed.
+    1. If next bytes are expected, the task repeats previous 3 steps.
+1. The upload status is returned to the consumer or an exception is thrown if the upload failed.
+
+### Example of a response calling for the upload of the next range
+
+```json
+{
+"@odata.context":"https://outlook.office.com/api/v2.0/$metadata#Users('<redacted>')/Messages('<redacted>')/AttachmentSessions/$entity",
+"expirationDateTime":"2019-09-25T01:09:30.7671707Z",
+"nextExpectedRanges":["2097152"]
+}
+```
+
+> Warning: In case the large upload task is targeting Outlook APIs, it is possible the casing of the json properties is different (i.e. **ExpirationDateTime** instead of **expirationDateTime**). Implementation should account for this.
 
 ## Performance Considerations
 

--- a/tasks/FileUploadTask.md
+++ b/tasks/FileUploadTask.md
@@ -16,15 +16,19 @@ This task aims to provide a fluent and easy to use mechanism for the consumer to
 - The task should signal upload completion via by returning the status or returning a completed **Task**/**Promise**/**Future** for async APIs.
 - Using the RequestContext, the feature flag for the **FileUploadTask** can be set for telemetry purposes.
 - The task should not retry to upload failed slices as any retry should already be done by the retry-handler which the task should be using.
-- The task should be agnostic to the kind of upload being performed so as to support for various fileUpload scenarios e.g. **DriveItem** and **FileAttachment**.
 - The task should provide cancellation capabilities through native task cancellation sources when using async APIs.
 - The task classes naming should match **LargeFileUploadXXX** (provider, result...) and all the classes should live in a **tasks** subnamespace, and be sharing the same  namespace as the **PageIterator** task.
-- An upload task should be marked as completed if the response status is a 201. Another condition valid only for OneDrive is if the response status is a 200 and the response contains an "id" then the task is complete. Note - Outlook and Print API does not allow to update an attachment.
-- Refer to the following documentation for more information:
+- The task should be agnostic to the kind of upload being performed so as to support for various fileUpload scenarios e.g. **DriveItem** and **FileAttachment**. An example of the agnostic nature of task is how the task is marked as completed considering different response formats from each API:
+  - If the response status is a 201.
+  - For OneDrive if the response status is a 200 and the response contains an "id" then the task is complete.
+  
+> Note: Outlook and Print API does not allow to update an attachment after it has been uploaded.
 
-  - [Outlook](https://docs.microsoft.com/en-us/graph/outlook-large-attachments?tabs=javascript)
-  - [OneDriveItem](https://docs.microsoft.com/en-us/graph/api/driveitem-createuploadsession?view=graph-rest-1.0&preserve-view=true)
-  - [Print API](https://docs.microsoft.com/en-us/graph/upload-data-to-upload-session)
+Refer to the following documentation for more information:
+
+- [Outlook](https://docs.microsoft.com/en-us/graph/outlook-large-attachments)
+- [OneDriveItem](https://docs.microsoft.com/en-us/graph/api/driveitem-createuploadsession?view=graph-rest-1.0&preserve-view=true)
+- [Print API](https://docs.microsoft.com/en-us/graph/upload-data-to-upload-session)
 
 ## Large File Upload Result Prototype
 


### PR DESCRIPTION
This pull request cleans up some of the language in the requirement, markdown formatting and updates the java samples.

Items left to discuss:

- Should we align the object model naming in the spec? (currently ChunkedUploadProvider is not really informative for Java)
- Should the task try to get the result (issuing a sub-query) after the upload completes on an empty response with a location header pointing to a resource on graph?
- Alternatively, should the task return a wrapper object instead of the direct type, so we could provide the type whenever available, or response information when not available?

We can have the discussion here before we merge that pull request. This way I can make subsequent updates before we merge this PR.