### PR TITLE
Introduce `CustomHosts` option

### DIFF
--- a/GraphClientFactory.md
+++ b/GraphClientFactory.md
@@ -18,18 +18,31 @@ There are two primary usage scenarios for the client factory.  Developers who wi
   - Set the SdkVersion header with the appropriate moniker based on the following structure `graph-{lang}-{version}`.  
 - Enable the developer to select a supported sovereign cloud using an enumerated list.  Selecting the sovereign cloud should ensure that the AuthenticationProvider uses the appropriate Authentication Endpoint.
 - Enable a developer to configure a HTTP proxy that will be used for outgoing requests.
-- Enable a developer provide custom URLs or endpoints. 
-  - `CustomURLs` option should be set on client creation.
+- Enable a developer to provide custom hosts. 
+  - `CustomHosts` option should be set on client creation.
+  - `CustomHosts` option should be made available in the `Context` so that it is available to the middleware during request processing.
   - These URLs are different from the Graph service endpoints on the national clouds. 
   - Certain workloads error out when an unexpected header is present in the request. The middlewares should check: 
-    - If the request URL is a Graph serve endpoint or a custom url provided by the developer, then append request headers or modify the request content.
+    - If the request URL is a Graph service endpoint or a custom host provided by the developer, then append request headers or modify the request content.
     - Else the middleware should delete request headers added by that middleware.
+  - Example of an workload error - [LargeFileUploadTask upload to OneDrive caused CORS error due `SDKVersion` telemetry header](https://github.com/microsoftgraph/msgraph-sdk-javascript/issues/265)
   - Provide capabilities to modify or update the `CustomURLs` option after the client creation.  
  
 ## Performance Considerations
 
 - If available on the platform, enable gzip compression of requests and responses.
 
+## Future Implementation
+
+- Enable developers to set `CustomHosts`. The progress can be tracked as follows:
+```
+| SDK         | Implementation Status|
+|-------------|----------------------|
+| C#          | -                    |
+| JAVA        | -                    |
+| PHP         | -                    |
+| JavaScript  | In Progress          |
+```
 ## Security Considerations
 
 - If available on the platform, configure for TLS 1.2

--- a/GraphClientFactory.md
+++ b/GraphClientFactory.md
@@ -21,12 +21,12 @@ There are two primary usage scenarios for the client factory.  Developers who wi
 - Enable a developer to provide custom hosts. 
   - `CustomHosts` option should be set on client creation.
   - `CustomHosts` option should be made available in the `Context` so that it is available to the middleware during request processing.
-  - These URLs are different from the Graph service endpoints on the national clouds. 
+  - These hostnames are different from the Graph service endpoints on the national clouds. 
   - Certain workloads error out when an unexpected header is present in the request. The middlewares should check: 
     - If the request URL is a Graph service endpoint or a custom host provided by the developer, then append request headers or modify the request content.
     - Else the middleware should delete request headers added by that middleware.
   - Example of an workload error - [LargeFileUploadTask upload to OneDrive caused CORS error due `SDKVersion` telemetry header](https://github.com/microsoftgraph/msgraph-sdk-javascript/issues/265)
-  - Provide capabilities to modify or update the `CustomURLs` option after the client creation.  
+  - Provide capabilities to modify or update the `CustomHosts` option after the client creation.  
  
 ## Performance Considerations
 

--- a/GraphClientFactory.md
+++ b/GraphClientFactory.md
@@ -18,7 +18,14 @@ There are two primary usage scenarios for the client factory.  Developers who wi
   - Set the SdkVersion header with the appropriate moniker based on the following structure `graph-{lang}-{version}`.  
 - Enable the developer to select a supported sovereign cloud using an enumerated list.  Selecting the sovereign cloud should ensure that the AuthenticationProvider uses the appropriate Authentication Endpoint.
 - Enable a developer to configure a HTTP proxy that will be used for outgoing requests.
-
+- Enable a developer provide custom URLs or endpoints. 
+  - `CustomURLs` option should be set on client creation.
+  - These URLs are different from the Graph service endpoints on the national clouds. 
+  - Certain workloads error out when an unexpected header is present in the request. The middlewares should check: 
+    - If the request URL is a Graph serve endpoint or a custom url provided by the developer, then append request headers or modify the request content.
+    - Else the middleware should delete request headers added by that middleware.
+  - Provide capabilities to modify or update the `CustomURLs` option after the client creation.  
+ 
 ## Performance Considerations
 
 - If available on the platform, enable gzip compression of requests and responses.

--- a/middleware/AuthorizationHandler.md
+++ b/middleware/AuthorizationHandler.md
@@ -10,6 +10,10 @@ A piece of client-side middleware intended to allow the use of an authorization 
 - Transparently authorize requests
 - Accept AuthorizationProvider instance in constructor
 - Update Authorization Header
+- Certain workloads error out when an unexpected header is present in the request. The middlewares should check:
+  - If the request URL is a Graph serve endpoint or a custom url provided by the developer, then append or update the authorization header.
+  - Else the middleware should delete authorization header.
+ 
 
 Take a request object and use authorization provider to add Authorization header.  
 

--- a/middleware/TelemetryHandler.md
+++ b/middleware/TelemetryHandler.md
@@ -36,6 +36,10 @@ Provide a mandatory middleware component that attaches metadata to a Graph reque
     - `RuntimeEnvironment: Node/1.1` for JavaScript.
     - `RuntimeEnvironment: JRE/1.1` for Java.
 
+- Certain workloads error out when an unexpected header is present in the request. The middlewares should check:
+  - If the request URL is a Graph serve endpoint or a custom url provided by the developer, then append or update the telemetry headers.
+  - Else the middleware should delete telemetry header.
+
 #### Ideal Metadata Capture
 ```
 SdkVersion: graph-dotnet-beta/0.6.0-preview, graph-dotnet-core/1.16.0 (featureUsage=0f)


### PR DESCRIPTION
Certain workloads error out when an unexpected header is present in the request.

Example - 

In case of `LargeFileUploadTask` in JS library, the upload is as follows:

```
client.api("UPLOAD_URL").put(chunk_to_be_uploaded)
```
The middleware appends request headers which are meant for the Graph API.  

- When I tried uploading to `Outlook`, an error  was caused because of `Authorization` header.
- [LargeFileUploadTask upload to OneDrive caused cors issue due  `sdkversion` telemetry header](https://github.com/microsoftgraph/msgraph-sdk-javascript/issues/265#issue-556249096)

The solution for this is to add a check if the request URL is a Graph endpoint and not send headers to `UPLOAD_URL`.

Adding the headers only for Graph endpoints ignores the case where the developer might have their own test endpoints. 
Example - 
MGT uses a proxy sandbox environment
or 
> Support Custom Graph Endpoint graph.microsoft-ppe.com

https://github.com/microsoftgraph/microsoft-graph-toolkit/issues/1053

I had a conversation with @darrelmiller about handling this case and he proposed that we allow developers to provide custom endpoints and update our conditions to modify request headers.