### PR TITLE
- adds a new specification for request compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository holds documents related to current and on-going work on Microsoft Graph SDKs.  The following diagram shows a high level view of the SDK component architecture. The goal is to enable developers to opt-into functionality that they wish to use.  Over time all the SDKs will be adapted to follow this pattern.
 
-![Component Architecure](images/componentArch.png)
+![Component Architecture](images/componentArch.png)
 
 ## SDK Features Support
 
@@ -13,7 +13,8 @@ This repository holds documents related to current and on-going work on Microsof
 | | [Authorization Handler](middleware/AuthorizationHandler.md)   |[✓][dotnet_authhandler] |[✓][java_authhandler]|[✓][js_authhandler]|[✓][objc_authhandler] | | | |[✓][python_authhandler] | N/A |
 | | [Retry Handler](middleware/RetryHandler.md)              |[✓][dotnet_retryhandler]|[✓][java_retryhandler]|[✓][js_retryhandler]|[✓][objc_retryhandler]| | | | [✓][python_retryhandler]| [✓][go_retryhandler]
 | | [Redirect Handler](middleware/RedirectHandler.md)        |[✓][dotnet_redirecthandler]|[✓][java_redirecthandler]|[✓][js_redirecthandler]|[✓][objc_redirecthandler] | | | |✓ | [✓][go_redirecthandler]|
-| | [Compression Handler](middleware/CompressionHandler.md) |[✓][dotnet_compressionhandler]|N|N|N| | |
+| | [Request compression Handler](middleware/CompressionHandler.md) | | | | | | |
+| | [Response decompression Handler](middleware/DecompressionHandler.md) |[✓][dotnet_decompressionhandler]|N|N|N| | |
 | | [Logging Handler](middleware/LoggingHandler.md) |O| | | | | |
 | | [Telemetry Handler](middleware/TelemetryHandler.md) |[✓][dotnet_telemetryhandler]|[✓][java_telemetryhandler]|✓|✓| | | |[✓][python_telemetryhandler] | [✓][go_telemetryhandler]|
 | | Connection Management | | | | | | |
@@ -139,7 +140,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 [dotnet_retryhandler]: https://github.com/microsoftgraph/msgraph-sdk-dotnet/blob/dev/src/Microsoft.Graph.Core/Requests/Middleware/RetryHandler.cs
 [dotnet_redirecthandler]: https://github.com/microsoftgraph/msgraph-sdk-dotnet/blob/dev/src/Microsoft.Graph.Core/Requests/Middleware/RedirectHandler.cs
 [dotnet_authhandler]: https://github.com/microsoftgraph/msgraph-sdk-dotnet/blob/dev/src/Microsoft.Graph.Core/Requests/Middleware/AuthenticationHandler.cs
-[dotnet_compressionhandler]: https://github.com/microsoftgraph/msgraph-sdk-dotnet/blob/dev/src/Microsoft.Graph.Core/Requests/Middleware/CompressionHandler.cs
+[dotnet_decompressionhandler]: https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/blob/dev/src/Microsoft.Graph.Core/Requests/Middleware/CompressionHandler.cs
 [dotnet_clientfactory]: https://github.com/microsoftgraph/msgraph-sdk-dotnet/blob/dev/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
 [dotnet_batchrequestcontent]: https://github.com/microsoftgraph/msgraph-sdk-dotnet/blob/dev/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
 [dotnet_batchresponsecontent]: https://github.com/microsoftgraph/msgraph-sdk-dotnet/blob/dev/src/Microsoft.Graph.Core/Requests/Content/BatchResponseContent.cs

--- a/middleware/CompressionHandler.md
+++ b/middleware/CompressionHandler.md
@@ -1,47 +1,64 @@
 # Compression Handler
 
-A middleware component that requests, detects and decompresses response bodies.
+A middleware component that compresses request bodies and falls back to an uncompressed body if the API doesn't support request body compression.
 
 ## Requirements
 
-- Add `Accept-encoding: gzip` to request headers.
-- Decompress response bodies that have the header `Content-Encoding: gzip`
+- Add `Content-encoding: gzip` to request headers for requests with a body.
+- Compresses request bodies.
+- Should the handler receive a [415 Unsupported Media Type](https://httpwg.org/specs/rfc7231.html#status.415) response or a `400 Bad Request` response with an OData error containing the following message `Unable to read JSON request payload. Please ensure Content-Type header is set and payload is of valid JSON format.` when the content-type was `application/json`, the handler will retry sending the request without compressing it a maximum of one time before passing on the error.
 - Compression handler should be installed as a default handler by [GraphClientFactory](../GraphClientFactory.md)
 
 ## Remarks
 
-Ideally we would compress request payloads also, however it appears that Microsoft Graph gateway currently does not support accepting compressed request bodies.  
+For response payload decompression, refer to the [decompression handler](./DecompressionHandler.md) specification.
 
-This middleware is currently not required in JavaSript as the Fetch API already supports decompressing responses automatically and automatically adds the accept-encoding header.  If Microsoft Graph accepts compressed responses at some point in the future then we should add request compression middleware to Javascript also.
+This handler MUST be inserted BEFORE the [Retry handler](./RetryHanlder.md) to avoid compressing the request payload multiple times over.
+
+This handler is part of the Graph handlers collection and not the Kiota handler collection because of how it handles bad requests being specific to Microsoft Graph APIs.
+
+Microsoft Graph environments which do not support request body compression yet return a 400 response code instead of 415.
 
 ## Example
 
-```csharp
+### HTTP request with compressed body
 
-    public class CompressionHandler : DelegatingHandler
-    {
-        protected async override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            // Declare compression support to server
-            var gzipQString = new StringWithQualityHeaderValue("gzip");
-            if (!request.Headers.AcceptEncoding.Contains(gzipQString))
-            {
-                request.Headers.AcceptEncoding.Add(gzipQString);
-            }
+```http
+POST https://graph.microsoft.com/v1.0/me/microsoft.graph.sendMail HTTP/1.1
+Host: graph.microsoft.com
+SdkVersion: Graph-dotnet-2.0.5
+FeatureFlag: 00000047
+Cache-Control: no-store, no-cache
+Authorization: Bearer {token}
+Accept-Encoding: gzip
+Transfer-Encoding: chunked
+Content-Type: application/json
+Content-Encoding: gzip
+…compressed body….
+```
 
-            // Record feature usage for telemetry
-            var requestContext = request.GetRequestContext();
-            requestContext.FeatureUsage |= FeatureFlag.CompressionHandler;
+### HTTP response from Microsoft Graph when request compression is not supported
 
-            // Send Request
-            var response = await base.SendAsync(request, cancellationToken);
+```http
+HTTP/1.1 400 Bad Request
 
-            // Decompress gzipped responses
-            if (response.Content != null && response.Content.Headers.ContentEncoding.Contains("gzip"))
-            {
-                response.Content = new StreamContent(new GZipStream(await response.Content.ReadAsStreamAsync(), CompressionMode.Decompress));
-            }
-            return response;
-        }
-    }
+Date: Thu, 09 Dec 2021 03:37:07 GMT
+
+Content-Type: application/json
+
+Vary: Accept-Encoding
+
+Strict-Transport-Security: max-age=31536000
+
+request-id: 38b4ee5c-1168-4281-863b-920860a4eebe
+
+client-request-id: 38b4ee5c-1168-4281-863b-920860a4eebe
+
+x-ms-ags-diagnostic: {"ServerInfo":{"DataCenter":"Canada East","Slice":"E","Ring":"2","ScaleUnit":"001","RoleInstance":"QB1PEPF0000111E"}}
+
+Content-Length: 313
+
+ 
+
+{"error":{"code":"BadRequest","message":"Unable to read JSON request payload. Please ensure Content-Type header is set and payload is of valid JSON format.","innerError":{"date":"2021-12-09T03:37:08","request-id":"38b4ee5c-1168-4281-863b-920860a4eebe","client-request-id":"38b4ee5c-1168-4281-863b-920860a4eebe"}}}
 ```

--- a/middleware/DecompressionHandler.md
+++ b/middleware/DecompressionHandler.md
@@ -1,0 +1,47 @@
+# Decompression Handler
+
+A middleware component that requests, detects and decompresses response bodies.
+
+## Requirements
+
+- Add `Accept-encoding: gzip` to request headers.
+- Decompress response bodies that have the header `Content-Encoding: gzip`
+- Compression handler should be installed as a default handler by [GraphClientFactory](../GraphClientFactory.md)
+
+## Remarks
+
+For request payload compression, refer to the [compression handler](./CompressionHandler.md) specification.
+
+This middleware is currently not required in JavaScript as the Fetch API already supports decompressing responses automatically and automatically adds the accept-encoding header.  If Microsoft Graph accepts compressed responses at some point in the future then we should add request compression middleware to Javascript also.
+
+## Example
+
+```csharp
+
+    public class DecompressionHandler : DelegatingHandler
+    {
+        protected async override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            // Declare compression support to server
+            var gzipQString = new StringWithQualityHeaderValue("gzip");
+            if (!request.Headers.AcceptEncoding.Contains(gzipQString))
+            {
+                request.Headers.AcceptEncoding.Add(gzipQString);
+            }
+
+            // Record feature usage for telemetry
+            var requestContext = request.GetRequestContext();
+            requestContext.FeatureUsage |= FeatureFlag.CompressionHandler;
+
+            // Send Request
+            var response = await base.SendAsync(request, cancellationToken);
+
+            // Decompress gzipped responses
+            if (response.Content != null && response.Content.Headers.ContentEncoding.Contains("gzip"))
+            {
+                response.Content = new StreamContent(new GZipStream(await response.Content.ReadAsStreamAsync(), CompressionMode.Decompress));
+            }
+            return response;
+        }
+    }
+```


### PR DESCRIPTION
AGS is adding support for request payload compression, meaning that if our SDKs send them a comrpessed payload, they'll be able to decompress it.

This is especially important for low bandwidth scenarios, high throughput scenarios and large payloads/file uploads.

This PR adds a specification for a compression handler. I've also renamed the existing compression handler to decompression handler to be closer to what it actually does.

Here are a couple of reasons why I kept the compression and decompression handlers separate:

- A lot of native clients perform the decompression natively, effectively we don't have/need a decompression handler.
- A customer might want to disable request compression, but keep response decompression, keeping handlers separate helps providing that kind of control.

